### PR TITLE
fix: use user_id instead of username in urls

### DIFF
--- a/osschallenge/templates/osschallenge/index.html
+++ b/osschallenge/templates/osschallenge/index.html
@@ -30,7 +30,7 @@
                     </button>
                     {% if request.user.is_authenticated %}
                         <div class="logged-in-user">
-                            <a class="link" href="/profile/{{ request.user.username }}">{% trans "Logged in as" %} {{ request.user.username }}</a>
+                            <a class="link" href="/profile/{{ request.user.id }}">{% trans "Logged in as" %} {{ request.user.username }}</a>
                         </div>
                     {% endif %}
                 </header>
@@ -41,7 +41,7 @@
                             <a class="link" href="/projects">{% trans "Projects" %}</a>
                         </li>
                         <li class="nav-top-list-item">
-                            <a class="link" href="/my_tasks/{{ request.user.username }}">{% trans "Tasks" %}</a>
+                            <a class="link" href="/my_tasks/{{ request.user.id }}">{% trans "Tasks" %}</a>
                         </li>
                         <li class="nav-top-list-item">
                             <a class="link" href="/ranking">{% trans "Ranking" %}</a>
@@ -50,7 +50,7 @@
                             <a class="link" href="/about">{% trans "About" %}</a>
                         </li>
                         <li class="nav-top-list-item">
-                            <a class="link" href="/profile/{{ request.user.username }}">{% trans "Profile" %}</a>
+                            <a class="link" href="/profile/{{ request.user.id }}">{% trans "Profile" %}</a>
                         </li>
                         <li class="nav-top-list-item">
                             <a id="logout" class="link" href="/logout">Logout</a>

--- a/osschallenge/templates/osschallenge/profile.html
+++ b/osschallenge/templates/osschallenge/profile.html
@@ -7,7 +7,7 @@
 <meta property="og:title" content="OSS-Challenge" />
 <meta property="og:type" content="profile:username" />
 <meta property="og:image" content="{% if profile.picture.avatar.url %} {{ profile.picture.avatar.url }} {% else %} {% static "osschallenge/profile-example.png" %} {% endif %}" />
-<meta property="og:url" content="www.osschallenge.ch/profile/{{ user.username }}/" />
+<meta property="og:url" content="www.osschallenge.ch/profile/{{ user.id }}/" />
 <meta property="og:description" content="{{ user.username }}" />
 <meta property="og:description" content="{% if contributor != None %} {{total_points}} {% else %} 0 {% endif %} {% trans "Points reached." %}" />
 {% endblock meta %}
@@ -91,7 +91,7 @@
                     </a>
                 </div>
                 <div class="social-button" id="twitter">
-                    <a class="share-button" href="https://twitter.com/intent/tweet?hashtags=osschallenge&text={% blocktrans %}I%20reached%20{{total_points}}%20Points!{% endblocktrans %}&url=https://www.osschallenge.ch/profile/{{profile.user.username}}" target="_blank" title="{% trans "Tweet" %}" aria-label="{% trans "Tweet" %}">
+                    <a class="share-button" href="https://twitter.com/intent/tweet?hashtags=osschallenge&text={% blocktrans %}I%20reached%20{{total_points}}%20Points!{% endblocktrans %}&url=https://www.osschallenge.ch/profile/{{profile.user.id}}" target="_blank" title="{% trans "Tweet" %}" aria-label="{% trans "Tweet" %}">
                         <div class="social-icon" id="twitter-icon"></div>
                         <span>{% trans "Tweet" %}</span>
                     </a>

--- a/osschallenge/templates/osschallenge/project.html
+++ b/osschallenge/templates/osschallenge/project.html
@@ -24,14 +24,14 @@
             <p>
                 <strong>{% trans "Owner" %}</strong>
                 <br>
-                <a class="link-blue" href="/profile/{{ project.owner.username }}/">
+                <a class="link-blue" href="/profile/{{ project.owner.id }}/">
                     {{ owner }}</p>
                 </a>
             <p>
                 <strong>{% trans "Mentor" %}</strong>
                 <br>
                 {% for user in mentors %}
-                <a class="link-blue" href="/profile/{{ user.username }}/">
+                <a class="link-blue" href="/profile/{{ user.id }}/">
                     {{ user }}
                 </a>
                 {% endfor %}

--- a/osschallenge/templates/osschallenge/ranking.html
+++ b/osschallenge/templates/osschallenge/ranking.html
@@ -30,7 +30,7 @@
                 {% for user in users %}
                 {% if user.is_active %}
                 <tr>
-                    <td><a href="/profile/{{ user.username }}">{{ user.username }}</td>
+                    <td><a href="/profile/{{ user.id }}">{{ user.username }}</td>
                     <td>{{ user.task_count|get_rank }}</td>
                     <td>{{ user.task_count }}</td>
                     <td>{{ user.quarter_count }}</td>

--- a/osschallenge/templates/osschallenge/task.html
+++ b/osschallenge/templates/osschallenge/task.html
@@ -20,19 +20,19 @@
                     <i class="fa fa-check-circle-o" aria-hidden="true"></i>
                     {% trans "done" %}
                     {% if task.assignee_id %}
-                        {% trans "by" %} <a class="link-blue" href="/profile/{{ task.assignee }}/">{{ task.assignee }}</a>
+                        {% trans "by" %} <a class="link-blue" href="/profile/{{ task.assignee.id }}/">{{ task.assignee }}</a>
                     {% endif %}
                 {% elif task.assignee_id != NULL %}
                     <i class="fa fa-spinner" aria-hidden="true"></i>
-                    {% trans "claimed by" %} <a class="link-blue" href="/profile/{{ task.assignee }}/">{{ task.assignee }}</a>
+                    {% trans "claimed by" %} <a class="link-blue" href="/profile/{{ task.assignee.id }}/">{{ task.assignee }}</a>
                 {% endif %}
                 {% if task.task_checked == False %}
                     {% for user in mentors %}
-                        <br>{% trans "supervised by" %} <a class="link-blue" href="/profile/{{ user.username }}/">{{ user }}</a>
+                        <br>{% trans "supervised by" %} <a class="link-blue" href="/profile/{{ user.id }}/">{{ user }}</a>
                     {% endfor %}
                 {% elif task.task_checked %}
                     <br><i class="fa fa-check-circle" aria-hidden="true"></i>
-                    {% trans "approved by" %} <a class="link-blue" href="/profile/{{ task.approved_by.username }}/">{{ task.approved_by.username }}</a>
+                    {% trans "approved by" %} <a class="link-blue" href="/profile/{{ task.approved_by.id }}/">{{ task.approved_by.username }}</a>
                 {% endif %}
             </p>
             <p>{% trans task.lead_text %}</p>
@@ -92,12 +92,12 @@
                     <div class="card--inverse card--primary comment">
                         <div class="comment-title card-header">
                             {% if comment.author_id == mentor_id %}
-                            <a class="link-blue" href="/profile/{{ comment.author.username }}/">
+                            <a class="link-blue" href="/profile/{{ comment.author.id }}/">
                                 <b>{{ comment.author.first_name }} {{comment.author.last_name}}</b>
                                 <i class="fa fa-star" aria-hidden="true"><span class="hidden-span">{% trans "This user is mentor" %}</span></i>
                             </a>
                             {% else %}
-                            <a class="link-blue" href="/profile/{{ comment.author.username }}/"><b>{{ comment.author.username }}</b></a>
+                            <a class="link-blue" href="/profile/{{ comment.author.id }}/"><b>{{ comment.author.username }}</b></a>
                             {% endif %}
                         </div>
                         <div class="card-block-comment">

--- a/osschallenge/templates/osschallenge/taskindex.html
+++ b/osschallenge/templates/osschallenge/taskindex.html
@@ -13,11 +13,11 @@
                 {% if title %}
                     <h1>{{ title }}</h1>
                 {% endif %}
-                {% if user.is_authenticated and username %}
+                {% if user.is_authenticated and user_id %}
                     <a class="link-blue" href="/tasks">{% trans "Show all tasks" %}</a>
                 {% endif %}
-                {% if user.is_authenticated and  username == None %}
-                    <a class="link-blue" href="/my_tasks/{{ request.user.username }}">{% trans "Show my tasks" %}</a>
+                {% if user.is_authenticated and  user_id == None %}
+                    <a class="link-blue" href="/my_tasks/{{ request.user.id }}">{% trans "Show my tasks" %}</a>
                 {% endif %}
                 {% if mentor != None %}
                     <a class="link-blue" href="/tasks/admin/">{% trans "Show tasks to review" %}</a>

--- a/osschallenge/templates/registration/password_change_done.html
+++ b/osschallenge/templates/registration/password_change_done.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="content">
     <p>
-    {% blocktrans %}Your password has been changed. {% endblocktrans %}<a href="/profile/{{ request.user.username }}">{% trans "Back" %}</a>
+    {% blocktrans %}Your password has been changed. {% endblocktrans %}<a href="/profile/{{ request.user.id }}">{% trans "Back" %}</a>
     </p>
 </div>
 {% endblock %}

--- a/osschallenge/tests/pages/profil.py
+++ b/osschallenge/tests/pages/profil.py
@@ -7,9 +7,9 @@ class ProfilePage(object):
         self.driver = selenium_driver
         self.live_server_url = live_server_url
 
-    def open(self, username):
+    def open(self, user_id):
         self.driver.get(
-            "{}/profile/{}/".format(self.live_server_url, username)
+            "{}/profile/{}/".format(self.live_server_url, user_id)
         )
         return self
 

--- a/osschallenge/tests/pages/task.py
+++ b/osschallenge/tests/pages/task.py
@@ -21,9 +21,9 @@ class TaskPage(object):
         )
         return self
 
-    def open_page_one_my_tasks(self, username, page):
+    def open_page_one_my_tasks(self, user_id, page):
         self.driver.get(
-            "{}/my_tasks/{}/{}".format(self.live_server_url, username, page)
+            "{}/my_tasks/{}/{}".format(self.live_server_url, user_id, page)
         )
         return self
 

--- a/osschallenge/tests/test_selenium_logged_in_as_contributor.py
+++ b/osschallenge/tests/test_selenium_logged_in_as_contributor.py
@@ -137,17 +137,17 @@ class LoggedInAsContributor(SeleniumTests):
         self.assertEqual(comment.comment, "Hallo test")
 
     def test_set_profile_inactive(self):
-        # for unkown reason profile_page.open("Test") first redirects to rankup page
-        self.profile_page.open("Test")
-        self.profile_page.open("Test")
+        # for unkown reason profile_page.open() first redirects to rankup page
+        self.profile_page.open(self.user1.id)
+        self.profile_page.open(self.user1.id)
         self.profile_page.set_profile_inactive()
         user = User.objects.get(username=self.user1.username)
         self.assertFalse(user.is_active)
 
     def test_edit_first_name_in_profile(self):
-        # for unkown reason profile_page.open("Test") first redirects to rankup page
-        self.profile_page.open("Test")
-        self.profile_page.open("Test")
+        # for unkown reason profile_page.open() first redirects to rankup page
+        self.profile_page.open(self.user1.id)
+        self.profile_page.open(self.user1.id)
         self.profile_page.edit_first_name_in_profile("Foobar")
         user = User.objects.get(username=self.user1.username)
         self.assertEqual(user.first_name, "TestFoobar")
@@ -155,7 +155,7 @@ class LoggedInAsContributor(SeleniumTests):
     def test_view_rankup(self):
         self.profile1.rank = self.rank1
         self.profile1.save()
-        self.profile_page.open("Test")
+        self.profile_page.open(self.user1.id)
         self.assertEqual(self.profile1.rank_id, 1)
 
     def test_ranking_page_not_an_integer(self):
@@ -165,16 +165,16 @@ class LoggedInAsContributor(SeleniumTests):
         self.assertEquals(int(active_page.text), 1)
 
     def test_task_page_exists_on_all_tasks(self):
-        # for unkown reason task_page.open_page_one_all_tasks("Test") first redirects to rankup page
+        # for unkown reason task_page.open_page_one_all_tasks() first redirects to rankup page
         self.task_page.open_page_one_all_tasks('?page=1')
         self.task_page.open_page_one_all_tasks('?page=1')
         active_page = self.task_page.find_active_page()
         self.assertEquals(int(active_page.text), 1)
 
     def test_task_page_exists_on_my_tasks(self):
-        # for unkown reason task_page.open_page_one_my_tasks("Test") first redirects to rankup page
-        self.task_page.open_page_one_my_tasks('Test', '?page=1')
-        self.task_page.open_page_one_my_tasks('Test', '?page=1')
+        # for unkown reason task_page.open_page_one_my_tasks() first redirects to rankup page
+        self.task_page.open_page_one_my_tasks(self.user1.id, '?page=1')
+        self.task_page.open_page_one_my_tasks(self.user1.id, '?page=1')
         active_page = self.task_page.find_active_page()
         self.assertEquals(int(active_page.text), 1)
 
@@ -189,8 +189,8 @@ class LoggedInAsContributor(SeleniumTests):
         self.assertTrue(element)
 
     def test_no_redirect_profile(self):
-        # for unkown reason profile_page.open("Test") first redirects to rankup page
-        self.profile_page.open("Test")
-        self.profile_page.open("Test")
+        # for unkown reason profile_page.open() first redirects to rankup page
+        self.profile_page.open(self.user1.id)
+        self.profile_page.open(self.user1.id)
         element = self.profile_page.search_element('facebook')
         self.assertTrue(element)

--- a/osschallenge/tests/test_selenium_not_logged_in.py
+++ b/osschallenge/tests/test_selenium_not_logged_in.py
@@ -105,6 +105,6 @@ class NotLoggedInTest(SeleniumTests):
         self.assertTrue(element)
 
     def test_redirection_from_profile(self):
-        self.profile_page.open("Test")
+        self.profile_page.open(self.user1.id)
         element = self.profile_page.search_element('login')
         self.assertTrue(element)

--- a/osschallenge/tests/test_views.py
+++ b/osschallenge/tests/test_views.py
@@ -220,13 +220,13 @@ class ViewTestCase(TestCase):
         )
 
     def test_my_task_index_view(self):
-        url = reverse('mytask', args=[self.user1.username])
+        url = reverse('mytask', args=[self.user1.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'osschallenge/taskindex.html')
 
     def test_search_match_my_task_index_view(self):
-        url = reverse('mytask', args=[self.user4.username])
+        url = reverse('mytask', args=[self.user4.id])
         response = self.client.get(url, {'search': 'code'})
         self.assertEqual(
             len(response.context['tasks']),
@@ -234,7 +234,7 @@ class ViewTestCase(TestCase):
         )
 
     def test_search_no_match_my_task_index_view(self):
-        url = reverse('mytask', args=[self.user1.username])
+        url = reverse('mytask', args=[self.user1.id])
         response = self.client.get(url, {'search': 'test'})
         self.assertEqual(
             len(response.context['tasks']),
@@ -492,13 +492,13 @@ class ViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_profile_view(self):
-        url = reverse('profile', args=[self.user1.username])
+        url = reverse('profile', args=[self.user1.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'osschallenge/profile.html')
 
     def test_no_user(self):
-        url = reverse('profile', args=['testuser123'])
+        url = reverse('profile', args=['123'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
@@ -507,7 +507,7 @@ class ViewTestCase(TestCase):
 
     def test_no_profile(self):
         account = factories.UserFactory(is_active = False)
-        url = reverse('profile', args=[account.username])
+        url = reverse('profile', args=[account.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
@@ -515,7 +515,7 @@ class ViewTestCase(TestCase):
         )
 
     def test_profile_does_not_exist_anymore(self):
-        url = reverse('profile', args=[self.user2.username])
+        url = reverse('profile', args=[self.user2.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
@@ -552,7 +552,7 @@ class ViewTestCase(TestCase):
         )
         self.assertRedirects(
             response,
-            reverse('profile', args=[self.user1.username]),
+            reverse('profile', args=[self.user1.id]),
             status_code=302
         )
 
@@ -682,7 +682,7 @@ class ViewTestCase(TestCase):
         )
 
     def test_redirect_mytasks_to_rankup_view(self):
-        url_my_tasks = reverse('mytask', args=[self.user1.username])
+        url_my_tasks = reverse('mytask', args=[self.user1.id])
         response_my_tasks = self.client.get(url_my_tasks)
         self.assertEqual(response_my_tasks.status_code, 200)
         self.assertTemplateUsed(
@@ -702,7 +702,7 @@ class ViewTestCase(TestCase):
         )
 
     def test_redirect_profile_to_rankup_view(self):
-        url_profile = reverse('profile', args=[self.user1])
+        url_profile = reverse('profile', args=[self.user1.id])
         response_profile = self.client.get(url_profile)
         self.assertEqual(response_profile.status_code, 200)
         self.assertTemplateUsed(

--- a/osschallenge/urls.py
+++ b/osschallenge/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
         views.TaskIndexView,
         name='taskindex'),
 
-    re_path(r'^my_tasks/(?P<username>[0-9A-Za-z_\-\.\+\@]+)/$',
+    re_path(r'^my_tasks/(?P<user_id>[0-9]+)/$',
         views.TaskIndexView,
         name='mytask'),
 
@@ -63,7 +63,7 @@ urlpatterns = [
         views.EditProfileView,
         name='editprofile'),
 
-    re_path(r'^profile/(?P<username>[0-9A-Za-z_\-\.\+\@]+)/$',
+    re_path(r'^profile/(?P<user_id>[0-9]+)/$',
         views.ProfileView,
         name='profile'),
 

--- a/osschallenge/views.py
+++ b/osschallenge/views.py
@@ -109,14 +109,14 @@ def EditProjectView(request, pk):
     )
 
 
-def TaskIndexView(request, username=None):
+def TaskIndexView(request, user_id=None):
     template_name = 'osschallenge/taskindex.html'
     title = ""
     mentor = request.user.groups.filter(name='Mentor').first()
     if request.user.id is not None and rankup_check(request.user) is True:
         return redirect('/rankup/')
     search = request.GET.get('search') if request.GET else None
-    if username is not None:
+    if user_id is not None:
         title = _("My Tasks")
         current_user_id = request.user.id
         user_task_objects = Task.objects.filter(
@@ -153,7 +153,7 @@ def TaskIndexView(request, username=None):
         'last_page': last_page,
         'current_page': current_page,
         'mentor': mentor,
-        'username': username,
+        'user_id': user_id,
         'title': title
     })
 
@@ -293,9 +293,9 @@ def NewTaskView(request, pk):
 
 
 @login_required(login_url="/login/")
-def ProfileView(request, username):
+def ProfileView(request, user_id):
     try:
-        user = User.objects.get(username=username)
+        user = User.objects.get(id=user_id)
         profile = Profile.objects.get(user_id=user.id)
     except (Profile.DoesNotExist, User.DoesNotExist):
         return render(request, 'osschallenge/no_profile_available.html')
@@ -352,7 +352,7 @@ def EditProfileView(request):
         if form_profile.is_valid() and form_user.is_valid():
             profile = form_profile.save()
             user = form_user.save()
-            return redirect('profile', user.username)
+            return redirect('profile', user.id)
 
     else:
         form_profile = ProfileForm(instance=profile)


### PR DESCRIPTION
The regex for username in urls.py only allowed basic characters.
I could have changed the regex, but I think it's better to use user_id and keep the regex as simple as possible.